### PR TITLE
Fixed misplaced parenthesis that caused cron-style schedules init to fai...

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -142,7 +142,7 @@ Job.prototype.schedule = function(spec){
                 var inv = new Invocation(self, spec);
                 scheduleInvocation(inv);
                 success = self.trackInvocation(inv);
-            } else if (typeof(spec == 'object')) {
+            } else if (typeof(spec) == 'object') {
                 if (!(spec instanceof RecurrenceRule)) {
                     var r = new RecurrenceRule();
                     if ('year' in spec)


### PR DESCRIPTION
I fixed a minor issue (misplaced paren in a 'if') that breaks the cron-style schedules.

The code aims at doing : if (spec is of type Object) do something, else do something else.
With cron-style schedule the spec is of type String, so it should go the 'else' part.

However the code did "if (typeof (spec == "Object")) which always return True, so the cron-style schedule never went through the else clause.