### PR TITLE
test: fix failing tests

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -137,12 +137,16 @@ Job.prototype.schedule = function(spec){
                 success = self.trackInvocation(inv);
             }
         } else {
-            spec = dateSpec(spec);
-            if (typeof(spec) == 'object' && spec instanceof Date) {
+            var type = typeof(spec);
+            if (type === 'string') {
+                spec = new Date(spec);
+            }
+
+            if (spec instanceof Date) {
                 var inv = new Invocation(self, spec);
                 scheduleInvocation(inv);
                 success = self.trackInvocation(inv);
-            } else if (typeof(spec) == 'object') {
+            } else if (type === 'object') {
                 if (!(spec instanceof RecurrenceRule)) {
                     var r = new RecurrenceRule();
                     if ('year' in spec)
@@ -172,16 +176,6 @@ Job.prototype.schedule = function(spec){
 
     return success;
 };
-
-function dateSpec(spec) {
-    if (spec instanceof Date === true) {
-        var validDate = new Date(spec);
-        if (validDate.toString() !== 'Invalid Date' && validDate > new Date()) {
-            spec = validDate;
-        }
-    }
-    return spec;
-}
 
 /* API
   invoke()

--- a/test/job-test.js
+++ b/test/job-test.js
@@ -73,17 +73,15 @@ module.exports = {
       test.expect(1);
 
       var date = new Date(Date.now() + 3000);
-      var job = new schedule.Job();
+      var job = new schedule.Job(function() {
+        test.done();
+      });
 
       job.on('scheduled', function(runAtDate) {
         test.equal(runAtDate, date);
       });
 
       job.schedule(date);
-
-      setTimeout(function() {
-        test.done();
-      }, 3250);
     }
   },
   "#schedule(RecurrenceRule)": {


### PR DESCRIPTION
Fix the following tests:

- "Should accept a valid date string" @ date-convenience-methods-test.js
- "Job emits 'scheduled' event with 'run at' Date" @ job-test.js

To fix the first test, support for scheduling date strings has been added to
  `Job.schedule`. Also the `DateSpec` function has been removed as it seemed
  useless.

