### PR TITLE
fix failing tests for run job every month and run job every year

### DIFF
--- a/test/schedule-cron-jobs.js
+++ b/test/schedule-cron-jobs.js
@@ -93,7 +93,7 @@ module.exports = {
         "Runs job every month": function(test) {
             test.expect(3);
 
-            var timeout = 3 * 31 * 24 * 60 * 60 * 1000;
+            var timeout = 3 * 29.53 * 24 * 60 * 60 * 1000;
 
             var job = schedule.scheduleJob('0 0 0 1 * *', function() {
                 test.ok(true);
@@ -109,7 +109,7 @@ module.exports = {
         "Runs job every year": function(test) {
             test.expect(3);
 
-            var timeout = 3 * 366 * 24 * 60 * 60 * 1000;
+            var timeout = 3 * 365.25 * 24 * 60 * 60 * 1000;
 
             var job = schedule.scheduleJob('0 0 0 1 1 *', function() {
                 test.ok(true);


### PR DESCRIPTION
Using 366 days in a year and 31 days in a month was causing the tests to have 4 assertions instead of just 3.

- Changed days in a month to 29.53 http://en.wikipedia.org/wiki/Month
- Changed days in a year to 365.25 http://en.wikipedia.org/wiki/Year
