### PR TITLE
test: init fake timer to current date

### DIFF
--- a/test/schedule-cron-jobs.js
+++ b/test/schedule-cron-jobs.js
@@ -7,7 +7,9 @@ var clock;
 module.exports = {
     ".scheduleJob(cron_expr, fn)": {
         setUp: function(cb) {
+            var now = Date.now();
             clock = sinon.useFakeTimers();
+            clock.tick(now);
             cb();
         },
         "Runs job every second": function(test) {


### PR DESCRIPTION
- Fixes the cron tests so they run correctly in any timezone.